### PR TITLE
Fix code scanning alert no. 9: Server-side request forgery

### DIFF
--- a/shop-frontend/pages/api/review/[id].ts
+++ b/shop-frontend/pages/api/review/[id].ts
@@ -53,7 +53,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       });
   } else if (req.method === "GET") {
     try {
-      const response = await fetch(`${c.backendApiUrl}/api/products/${id}/ratings`);
+      if (!allowedIds.includes(sanitizedId)) {
+        res.status(400).json({ message: "Invalid ID" });
+        return;
+      }
+      const response = await fetch(`${c.backendApiUrl}/api/products/${sanitizedId}/ratings`);
       const reviews = await response.json();
 
       res.status(200).json({


### PR DESCRIPTION
Fixes [https://github.com/nais/examples/security/code-scanning/9](https://github.com/nais/examples/security/code-scanning/9)

To fix the SSRF vulnerability, we need to ensure that the `id` parameter is validated against a strict allow-list before it is used to construct the URL for the outgoing HTTP request. This will prevent attackers from manipulating the URL to target unintended endpoints.

1. Validate the `id` parameter against the `allowedIds` allow-list in both the POST and GET requests.
2. Ensure that the `id` parameter is sanitized and validated before constructing the URL for the outgoing HTTP request.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
